### PR TITLE
feat: add rkyv support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1128,7 +1128,7 @@ dependencies = [
 [[package]]
 name = "eth-types"
 version = "0.12.0"
-source = "git+https://github.com/scroll-tech/zkevm-circuits?branch=feat/rkyv#ade6eb5f5f3e9665f88d8f103b82a6a75cbfc438"
+source = "git+https://github.com/scroll-tech/zkevm-circuits?branch=feat/rkyv#3a1b4187a42536b7d65b646526e6b0eea2b915ae"
 dependencies = [
  "base64 0.13.1",
  "ethereum-types",
@@ -1191,7 +1191,7 @@ dependencies = [
 [[package]]
 name = "ethereum-types"
 version = "0.14.1"
-source = "git+https://github.com/scroll-tech/parity-common.git?branch=feat/rkyv#0ad534ef109ffae50754f06c3aae90ffad5abfab"
+source = "git+https://github.com/scroll-tech/parity-common.git?branch=feat/rkyv#3c9294bf598e3580a84c24265ffb45d99eb8fe63"
 dependencies = [
  "ethbloom",
  "fixed-hash",
@@ -1207,7 +1207,7 @@ dependencies = [
 [[package]]
 name = "ethers-core"
 version = "2.0.7"
-source = "git+https://github.com/scroll-tech/ethers-rs.git?branch=feat/rkyv#f8e0e13cdea04661ea06889819ca8082112e4386"
+source = "git+https://github.com/scroll-tech/ethers-rs.git?branch=feat/rkyv#61c82c83a44087dbcf43916dc77845702f9c2b15"
 dependencies = [
  "arrayvec",
  "bytes",
@@ -1270,7 +1270,7 @@ dependencies = [
 [[package]]
 name = "ethers-signers"
 version = "2.0.7"
-source = "git+https://github.com/scroll-tech/ethers-rs.git?branch=feat/rkyv#f8e0e13cdea04661ea06889819ca8082112e4386"
+source = "git+https://github.com/scroll-tech/ethers-rs.git?branch=feat/rkyv#61c82c83a44087dbcf43916dc77845702f9c2b15"
 dependencies = [
  "async-trait",
  "coins-bip32",
@@ -2038,7 +2038,7 @@ dependencies = [
 [[package]]
 name = "mpt-zktrie"
 version = "0.12.0"
-source = "git+https://github.com/scroll-tech/zkevm-circuits?branch=feat/rkyv#ade6eb5f5f3e9665f88d8f103b82a6a75cbfc438"
+source = "git+https://github.com/scroll-tech/zkevm-circuits?branch=feat/rkyv#3a1b4187a42536b7d65b646526e6b0eea2b915ae"
 dependencies = [
  "eth-types",
  "halo2curves",
@@ -2439,7 +2439,7 @@ checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 [[package]]
 name = "primitive-types"
 version = "0.12.2"
-source = "git+https://github.com/scroll-tech/parity-common.git?branch=feat/rkyv#0ad534ef109ffae50754f06c3aae90ffad5abfab"
+source = "git+https://github.com/scroll-tech/parity-common.git?branch=feat/rkyv#3c9294bf598e3580a84c24265ffb45d99eb8fe63"
 dependencies = [
  "fixed-hash",
  "impl-codec",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -138,6 +138,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "android-tzdata"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
+
+[[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anstream"
 version = "0.6.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -434,6 +449,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
 name = "base64ct"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -643,7 +664,11 @@ version = "0.4.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a21f936df1771bf62b77f047b726c4625ff2e8aa607c01ec06e5a05bd8463401"
 dependencies = [
+ "android-tzdata",
+ "iana-time-zone",
  "num-traits",
+ "serde",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -675,7 +700,7 @@ dependencies = [
  "anstream",
  "anstyle",
  "clap_lex",
- "strsim 0.11.1",
+ "strsim",
 ]
 
 [[package]]
@@ -894,9 +919,9 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.13.4"
+version = "0.20.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a01d95850c592940db9b8194bc39f4bc0e89dee5c4265e4b1807c34a9aba453c"
+checksum = "6f63b86c8a8826a49b8c21f08a2d07338eec8d900540f8630dc76284be802989"
 dependencies = [
  "darling_core",
  "darling_macro",
@@ -904,27 +929,27 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.13.4"
+version = "0.20.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "859d65a907b6852c9361e3185c862aae7fafd2887876799fa55f5f99dc40d610"
+checksum = "95133861a8032aaea082871032f5815eb9e98cef03fa916ab4500513994df9e5"
 dependencies = [
  "fnv",
  "ident_case",
  "proc-macro2",
  "quote",
- "strsim 0.10.0",
- "syn 1.0.109",
+ "strsim",
+ "syn 2.0.71",
 ]
 
 [[package]]
 name = "darling_macro"
-version = "0.13.4"
+version = "0.20.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c972679f83bdf9c42bd905396b6c3588a843a17f0f16dfcfa3e2c5d57441835"
+checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
 dependencies = [
  "darling_core",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -944,6 +969,16 @@ checksum = "f55bf8e7b65898637379c1b74eb1551107c8294ed26d855ceb9fd1a09cfc9bc0"
 dependencies = [
  "const-oid",
  "zeroize",
+]
+
+[[package]]
+name = "deranged"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
+dependencies = [
+ "powerfmt",
+ "serde",
 ]
 
 [[package]]
@@ -1128,7 +1163,7 @@ dependencies = [
 [[package]]
 name = "eth-types"
 version = "0.12.0"
-source = "git+https://github.com/scroll-tech/zkevm-circuits?branch=feat/rkyv#3a1b4187a42536b7d65b646526e6b0eea2b915ae"
+source = "git+https://github.com/scroll-tech/zkevm-circuits?branch=feat/rkyv#10a15f70bac59d7f15be87b5066f767ceb0aeaf4"
 dependencies = [
  "base64 0.13.1",
  "ethereum-types",
@@ -1191,7 +1226,7 @@ dependencies = [
 [[package]]
 name = "ethereum-types"
 version = "0.14.1"
-source = "git+https://github.com/scroll-tech/parity-common.git?branch=feat/rkyv#3c9294bf598e3580a84c24265ffb45d99eb8fe63"
+source = "git+https://github.com/scroll-tech/parity-common.git?branch=feat/rkyv#1fb41c018fe0a3525951fb9d5e1a50b3c17ca855"
 dependencies = [
  "ethbloom",
  "fixed-hash",
@@ -1207,7 +1242,7 @@ dependencies = [
 [[package]]
 name = "ethers-core"
 version = "2.0.7"
-source = "git+https://github.com/scroll-tech/ethers-rs.git?branch=feat/rkyv#61c82c83a44087dbcf43916dc77845702f9c2b15"
+source = "git+https://github.com/scroll-tech/ethers-rs.git?branch=feat/rkyv#b87a87b89a76c2e2fa73c8939dc392215f60c05f"
 dependencies = [
  "arrayvec",
  "bytes",
@@ -1270,7 +1305,7 @@ dependencies = [
 [[package]]
 name = "ethers-signers"
 version = "2.0.7"
-source = "git+https://github.com/scroll-tech/ethers-rs.git?branch=feat/rkyv#61c82c83a44087dbcf43916dc77845702f9c2b15"
+source = "git+https://github.com/scroll-tech/ethers-rs.git?branch=feat/rkyv#b87a87b89a76c2e2fa73c8939dc392215f60c05f"
 dependencies = [
  "async-trait",
  "coins-bip32",
@@ -1564,7 +1599,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http",
- "indexmap",
+ "indexmap 2.2.6",
  "slab",
  "tokio",
  "tokio-util",
@@ -1739,6 +1774,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "iana-time-zone"
+version = "0.1.60"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7ffbb5a1b541ea2561f8c41c087286cc091e21e556a4f09a8f6cbf17b69b141"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1794,12 +1852,24 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
+dependencies = [
+ "autocfg",
+ "hashbrown 0.12.3",
+ "serde",
+]
+
+[[package]]
+name = "indexmap"
 version = "2.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "168fb715dda47215e360912c096649d23d58bf392ac62f73919e831745e40f26"
 dependencies = [
  "equivalent",
  "hashbrown 0.14.5",
+ "serde",
 ]
 
 [[package]]
@@ -1809,7 +1879,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c77a3ae7d4761b9c64d2c030f70746ceb8cfba32dce0325a56792e0a4816c31"
 dependencies = [
  "ahash 0.8.11",
- "indexmap",
+ "indexmap 2.2.6",
  "is-terminal",
  "itoa",
  "log",
@@ -2038,7 +2108,7 @@ dependencies = [
 [[package]]
 name = "mpt-zktrie"
 version = "0.12.0"
-source = "git+https://github.com/scroll-tech/zkevm-circuits?branch=feat/rkyv#3a1b4187a42536b7d65b646526e6b0eea2b915ae"
+source = "git+https://github.com/scroll-tech/zkevm-circuits?branch=feat/rkyv#10a15f70bac59d7f15be87b5066f767ceb0aeaf4"
 dependencies = [
  "eth-types",
  "halo2curves",
@@ -2092,6 +2162,12 @@ checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
 dependencies = [
  "num-traits",
 ]
+
+[[package]]
+name = "num-conv"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
 
 [[package]]
 name = "num-derive"
@@ -2410,6 +2486,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
 name = "pprof"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2439,7 +2521,7 @@ checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 [[package]]
 name = "primitive-types"
 version = "0.12.2"
-source = "git+https://github.com/scroll-tech/parity-common.git?branch=feat/rkyv#3c9294bf598e3580a84c24265ffb45d99eb8fe63"
+source = "git+https://github.com/scroll-tech/parity-common.git?branch=feat/rkyv#1fb41c018fe0a3525951fb9d5e1a50b3c17ca855"
 dependencies = [
  "fixed-hash",
  "impl-codec",
@@ -3070,7 +3152,7 @@ version = "1.0.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4e0d21c9a8cae1235ad58a00c11cb40d4b1e5c784f1ef2c537876ed6ffd8b7c5"
 dependencies = [
- "indexmap",
+ "indexmap 2.2.6",
  "itoa",
  "ryu",
  "serde",
@@ -3090,24 +3172,32 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "1.14.0"
+version = "3.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "678b5a069e50bf00ecd22d0cd8ddf7c236f68581b03db652061ed5eb13a312ff"
+checksum = "69cecfa94848272156ea67b2b1a53f20fc7bc638c4a46d2f8abde08f05f4b857"
 dependencies = [
+ "base64 0.22.1",
+ "chrono",
+ "hex",
+ "indexmap 1.9.3",
+ "indexmap 2.2.6",
  "serde",
+ "serde_derive",
+ "serde_json",
  "serde_with_macros",
+ "time",
 ]
 
 [[package]]
 name = "serde_with_macros"
-version = "1.5.2"
+version = "3.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e182d6ec6f05393cc0e5ed1bf81ad6db3a8feedf8ee515ecdd369809bcce8082"
+checksum = "a8fee4991ef4f274617a51ad4af30519438dacb2f56ac773b08a1922ff743350"
 dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -3116,7 +3206,7 @@ version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
 dependencies = [
- "indexmap",
+ "indexmap 2.2.6",
  "itoa",
  "ryu",
  "serde",
@@ -3254,12 +3344,6 @@ name = "str_stack"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9091b6114800a5f2141aee1d1b9d6ca3592ac062dc5decb3764ec5895a47b4eb"
-
-[[package]]
-name = "strsim"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "strsim"
@@ -3456,6 +3540,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "time"
+version = "0.3.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885"
+dependencies = [
+ "deranged",
+ "itoa",
+ "num-conv",
+ "powerfmt",
+ "serde",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
+
+[[package]]
+name = "time-macros"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f252a68540fde3a3877aeea552b832b40ab9a69e318efd078774a01ddee1ccf"
+dependencies = [
+ "num-conv",
+ "time-core",
+]
+
+[[package]]
 name = "tiny-keccak"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3532,7 +3647,7 @@ version = "0.19.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
 dependencies = [
- "indexmap",
+ "indexmap 2.2.6",
  "toml_datetime",
  "winnow",
 ]
@@ -3543,7 +3658,7 @@ version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8534fd7f78b5405e860340ad6575217ce99f38d4d5c8f2442cb5ecb50090e1"
 dependencies = [
- "indexmap",
+ "indexmap 2.2.6",
  "toml_datetime",
  "winnow",
 ]
@@ -3839,6 +3954,15 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-core"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
+dependencies = [
+ "windows-targets 0.52.6",
+]
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4193,7 +4193,7 @@ dependencies = [
 [[package]]
 name = "zktrie"
 version = "0.3.0"
-source = "git+https://github.com/scroll-tech/zktrie.git?branch=main#23181f209e94137f74337b150179aeb80c72e7c8"
+source = "git+https://github.com/scroll-tech//zktrie.git?branch=next#47cd984687a09ef53a60d9939755fb28c8fbf5e3"
 dependencies = [
  "gobuild",
  "zktrie_rust",
@@ -4202,7 +4202,7 @@ dependencies = [
 [[package]]
 name = "zktrie_rust"
 version = "0.3.0"
-source = "git+https://github.com/scroll-tech/zktrie.git?branch=main#23181f209e94137f74337b150179aeb80c72e7c8"
+source = "git+https://github.com/scroll-tech//zktrie.git?branch=next#47cd984687a09ef53a60d9939755fb28c8fbf5e3"
 dependencies = [
  "hex",
  "lazy_static",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,6 +30,17 @@ dependencies = [
 
 [[package]]
 name = "ahash"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "891477e0c6a8957309ee5c45a6368af3ae14bb510732d2684ffa19af310920f9"
+dependencies = [
+ "getrandom",
+ "once_cell",
+ "version_check",
+]
+
+[[package]]
+name = "ahash"
 version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
@@ -556,6 +567,28 @@ name = "byte-slice-cast"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3ac9f8b63eca6fd385229b3675f6cc0dc5c8a5c8a54a59d4f52ffd670d87b0c"
+
+[[package]]
+name = "bytecheck"
+version = "0.6.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23cdc57ce23ac53c931e88a43d06d070a6fd142f2617be5855eb75efc9beb1c2"
+dependencies = [
+ "bytecheck_derive",
+ "ptr_meta",
+ "simdutf8",
+]
+
+[[package]]
+name = "bytecheck_derive"
+version = "0.6.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3db406d29fbcd95542e92559bed4d8ad92636d1ca8b3b72ede10b4bcc010e659"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
 
 [[package]]
 name = "bytemuck"
@@ -1095,9 +1128,10 @@ dependencies = [
 [[package]]
 name = "eth-types"
 version = "0.12.0"
-source = "git+https://github.com/scroll-tech/zkevm-circuits?branch=develop#2a992040db1aa5dfd51400777e71432483379dd9"
+source = "git+https://github.com/scroll-tech/zkevm-circuits?branch=feat/rkyv#ade6eb5f5f3e9665f88d8f103b82a6a75cbfc438"
 dependencies = [
  "base64 0.13.1",
+ "ethereum-types",
  "ethers-core",
  "ethers-signers",
  "halo2curves",
@@ -1107,9 +1141,11 @@ dependencies = [
  "num",
  "num-bigint",
  "poseidon-base",
+ "primitive-types",
  "regex",
  "revm-precompile",
  "revm-primitives",
+ "rkyv",
  "serde",
  "serde_json",
  "serde_with",
@@ -1155,8 +1191,7 @@ dependencies = [
 [[package]]
 name = "ethereum-types"
 version = "0.14.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02d215cbf040552efcbe99a38372fe80ab9d00268e20012b79fcd0f073edd8ee"
+source = "git+https://github.com/scroll-tech/parity-common.git?branch=feat/rkyv#0ad534ef109ffae50754f06c3aae90ffad5abfab"
 dependencies = [
  "ethbloom",
  "fixed-hash",
@@ -1164,6 +1199,7 @@ dependencies = [
  "impl-rlp",
  "impl-serde",
  "primitive-types",
+ "rkyv",
  "scale-info",
  "uint",
 ]
@@ -1171,19 +1207,22 @@ dependencies = [
 [[package]]
 name = "ethers-core"
 version = "2.0.7"
-source = "git+https://github.com/scroll-tech/ethers-rs.git?branch=v2.0.7#e32dfd62e7cdec31160b91c5a646883594a586ba"
+source = "git+https://github.com/scroll-tech/ethers-rs.git?branch=feat/rkyv#f8e0e13cdea04661ea06889819ca8082112e4386"
 dependencies = [
  "arrayvec",
  "bytes",
  "chrono",
  "elliptic-curve",
  "ethabi",
+ "ethereum-types",
  "generic-array",
  "hex",
  "k256",
  "num_enum",
  "open-fastrlp",
+ "primitive-types",
  "rand",
+ "rkyv",
  "rlp",
  "serde",
  "serde_json",
@@ -1197,7 +1236,7 @@ dependencies = [
 [[package]]
 name = "ethers-providers"
 version = "2.0.7"
-source = "git+https://github.com/scroll-tech/ethers-rs.git?branch=v2.0.7#e32dfd62e7cdec31160b91c5a646883594a586ba"
+source = "git+https://github.com/scroll-tech/ethers-rs.git?branch=feat/rkyv#f8e0e13cdea04661ea06889819ca8082112e4386"
 dependencies = [
  "async-trait",
  "auto_impl",
@@ -1231,7 +1270,7 @@ dependencies = [
 [[package]]
 name = "ethers-signers"
 version = "2.0.7"
-source = "git+https://github.com/scroll-tech/ethers-rs.git?branch=v2.0.7#e32dfd62e7cdec31160b91c5a646883594a586ba"
+source = "git+https://github.com/scroll-tech/ethers-rs.git?branch=feat/rkyv#f8e0e13cdea04661ea06889819ca8082112e4386"
 dependencies = [
  "async-trait",
  "coins-bip32",
@@ -1557,11 +1596,20 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+dependencies = [
+ "ahash 0.7.8",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 dependencies = [
- "ahash",
+ "ahash 0.8.11",
  "allocator-api2",
  "serde",
 ]
@@ -1751,7 +1799,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "168fb715dda47215e360912c096649d23d58bf392ac62f73919e831745e40f26"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.14.5",
 ]
 
 [[package]]
@@ -1760,7 +1808,7 @@ version = "0.11.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c77a3ae7d4761b9c64d2c030f70746ceb8cfba32dce0325a56792e0a4816c31"
 dependencies = [
- "ahash",
+ "ahash 0.8.11",
  "indexmap",
  "is-terminal",
  "itoa",
@@ -1990,7 +2038,7 @@ dependencies = [
 [[package]]
 name = "mpt-zktrie"
 version = "0.12.0"
-source = "git+https://github.com/scroll-tech/zkevm-circuits?branch=develop#2a992040db1aa5dfd51400777e71432483379dd9"
+source = "git+https://github.com/scroll-tech/zkevm-circuits?branch=feat/rkyv#ade6eb5f5f3e9665f88d8f103b82a6a75cbfc438"
 dependencies = [
  "eth-types",
  "halo2curves",
@@ -2391,13 +2439,13 @@ checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 [[package]]
 name = "primitive-types"
 version = "0.12.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b34d9fd68ae0b74a41b21c03c2f62847aa0ffea044eee893b4c140b37e244e2"
+source = "git+https://github.com/scroll-tech/parity-common.git?branch=feat/rkyv#0ad534ef109ffae50754f06c3aae90ffad5abfab"
 dependencies = [
  "fixed-hash",
  "impl-codec",
  "impl-rlp",
  "impl-serde",
+ "rkyv",
  "scale-info",
  "uint",
 ]
@@ -2448,6 +2496,26 @@ dependencies = [
  "rusty-fork",
  "tempfile",
  "unarray",
+]
+
+[[package]]
+name = "ptr_meta"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0738ccf7ea06b608c10564b31debd4f5bc5e197fc8bfe088f68ae5ce81e7a4f1"
+dependencies = [
+ "ptr_meta_derive",
+]
+
+[[package]]
+name = "ptr_meta_derive"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16b845dbfca988fa33db069c0e230574d15a3088f147a87b64c7589eb662c9ac"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -2558,6 +2626,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
 
 [[package]]
+name = "rend"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71fe3824f5629716b1589be05dacd749f6aa084c87e00e016714a8cdfccc997c"
+dependencies = [
+ "bytecheck",
+]
+
+[[package]]
 name = "reqwest"
 version = "0.11.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2649,7 +2726,7 @@ dependencies = [
  "dyn-clone",
  "enumn",
  "halo2curves",
- "hashbrown",
+ "hashbrown 0.14.5",
  "hex",
  "kzg-rs",
  "poseidon-base",
@@ -2682,6 +2759,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd124222d17ad93a644ed9d011a40f4fb64aa54275c08cc216524a9ea82fb09f"
 dependencies = [
  "digest 0.10.7",
+]
+
+[[package]]
+name = "rkyv"
+version = "0.7.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cba464629b3394fc4dbc6f940ff8f5b4ff5c7aef40f29166fd4ad12acbc99c0"
+dependencies = [
+ "bitvec",
+ "bytecheck",
+ "bytes",
+ "hashbrown 0.12.3",
+ "ptr_meta",
+ "rend",
+ "rkyv_derive",
+ "seahash",
+ "tinyvec",
+ "uuid 1.10.0",
+]
+
+[[package]]
+name = "rkyv_derive"
+version = "0.7.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7dddfff8de25e6f62b9d64e6e432bf1c6736c57d20323e15ee10435fbda7c65"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -2853,6 +2959,12 @@ dependencies = [
  "salsa20",
  "sha2",
 ]
+
+[[package]]
+name = "seahash"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
 
 [[package]]
 name = "sec1"
@@ -3053,6 +3165,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "simdutf8"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f27f6278552951f1f2b8cf9da965d10969b2efdea95a6ec47987ab46edfe263a"
+
+[[package]]
 name = "slab"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3117,6 +3235,7 @@ dependencies = [
  "mpt-zktrie",
  "pprof",
  "revm",
+ "rkyv",
  "serde",
  "serde_json",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,23 +6,24 @@ edition = "2021"
 [dependencies]
 log = "0.4"
 hex = "0.4"
-eth-types = { git = "https://github.com/scroll-tech/zkevm-circuits", features = ["scroll"], branch = "develop" }
-mpt-zktrie = { git = "https://github.com/scroll-tech/zkevm-circuits", branch = "develop" }
+eth-types = { git = "https://github.com/scroll-tech/zkevm-circuits", features = ["scroll"], branch = "feat/rkyv" }
+mpt-zktrie = { git = "https://github.com/scroll-tech/zkevm-circuits", branch = "feat/rkyv" }
 revm = { git = "https://github.com/scroll-tech/revm", branch = "scroll-evm-executor/v40" , default-features = false, features = ["scroll-default-handler", "std", "optional_no_base_fee"] } # v40
 zktrie = { git = "https://github.com/scroll-tech/zktrie.git", branch = "main", features= ["rs_zktrie"] }
+rkyv = "0.7"
 
 # for local development
 #eth-types = { path = "../zkevm-circuits/eth-types", features = ["scroll"] }
 #mpt-zktrie = { path = "../zkevm-circuits/zktrie" }
-#revm = {path = "../revm/crates/revm", default-features = false, features = ["scroll-default-handler", "std", "optional_no_base_fee"] } # v37
+#revm = {path = "../revm/crates/revm", default-features = false, features = ["scroll-default-handler", "std", "optional_no_base_fee"] } # v40
 
 # binary dependencies
 anyhow = { version = "1.0", optional = true }
 async-channel = { version = "2.2", optional = true }
 clap = { version = "4", optional = true }
 env_logger = { version = "0.9", optional = true }
-ethers-core = { git = "https://github.com/scroll-tech/ethers-rs.git", branch = "v2.0.7", optional = true }
-ethers-providers = { git = "https://github.com/scroll-tech/ethers-rs.git", branch = "v2.0.7", default-features = false, optional = true }
+ethers-core = { git = "https://github.com/scroll-tech/ethers-rs.git", branch = "feat/rkyv", optional = true }
+ethers-providers = { git = "https://github.com/scroll-tech/ethers-rs.git", branch = "feat/rkyv", default-features = false, optional = true }
 futures = { version = "0.3", optional = true }
 url = { version = "2.5", optional = true }
 serde_json = { version = "1.0", optional = true }
@@ -34,11 +35,11 @@ csv = { version = "1.3", optional = true }
 pprof = { version = "0.13", features = ["flamegraph"], optional = true }
 
 # for local development
-# [patch."https://github.com/scroll-tech/zkevm-circuits"]
-# eth-types = { path = "../zkevm-circuits/eth-types" }
-# mpt-zktrie = { path = "../zkevm-circuits/zktrie" }
-# [patch."https://github.com/scroll-tech/revm"]
-# revm = { path = "../revm/crates/revm" }
+#[patch."https://github.com/scroll-tech/zkevm-circuits"]
+#eth-types = { path = "../zkevm-circuits/eth-types" }
+#mpt-zktrie = { path = "../zkevm-circuits/zktrie" }
+#[patch."https://github.com/scroll-tech/revm"]
+#revm = { path = "../revm/crates/revm" }
 
 [[bin]]
 name = "stateless-block-verifier"
@@ -70,10 +71,11 @@ debug-account = ["csv", "revm/serde"]
 debug-storage = ["csv", "revm/serde"]
 
 [patch.crates-io]
-ethers-core = { git = "https://github.com/scroll-tech/ethers-rs.git", branch = "v2.0.7" }
-ethers-providers = { git = "https://github.com/scroll-tech/ethers-rs.git", branch = "v2.0.7" }
-ethers-signers  = { git = "https://github.com/scroll-tech/ethers-rs.git", branch = "v2.0.7" }
+ethers-core = { git = "https://github.com/scroll-tech/ethers-rs.git", branch = "feat/rkyv" }
+ethers-signers  = { git = "https://github.com/scroll-tech/ethers-rs.git", branch = "feat/rkyv" }
 halo2curves = { git = "https://github.com/scroll-tech/halo2curves", branch = "v0.1.0" }
+primitive-types = { git = "https://github.com/scroll-tech/parity-common.git", branch = "feat/rkyv" }
+ethereum-types = { git = "https://github.com/scroll-tech/parity-common.git", branch = "feat/rkyv" }
 
 [patch."https://github.com/privacy-scaling-explorations/bls12_381"]
 bls12_381 = { git = "https://github.com/scroll-tech/bls12_381", branch = "feat/impl_scalar_field" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,8 @@ rkyv = { version = "0.7", features = ["validation"] }
 #eth-types = { path = "../zkevm-circuits/eth-types", features = ["scroll"] }
 #mpt-zktrie = { path = "../zkevm-circuits/zktrie" }
 #revm = {path = "../revm/crates/revm", default-features = false, features = ["scroll-default-handler", "std", "optional_no_base_fee"] } # v40
+#zktrie = { path = "../zktrie", features= ["rs_zktrie"] }
+
 
 # binary dependencies
 anyhow = { version = "1.0", optional = true }
@@ -69,6 +71,8 @@ bin-deps = [
 profiling = ["pprof"]
 debug-account = ["csv", "revm/serde"]
 debug-storage = ["csv", "revm/serde"]
+sp1 = []
+cycle-tracker = []
 
 [patch.crates-io]
 ethers-core = { git = "https://github.com/scroll-tech/ethers-rs.git", branch = "feat/rkyv" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ hex = "0.4"
 eth-types = { git = "https://github.com/scroll-tech/zkevm-circuits", features = ["scroll"], branch = "feat/rkyv" }
 mpt-zktrie = { git = "https://github.com/scroll-tech/zkevm-circuits", branch = "feat/rkyv" }
 revm = { git = "https://github.com/scroll-tech/revm", branch = "scroll-evm-executor/v40" , default-features = false, features = ["scroll-default-handler", "std", "optional_no_base_fee"] } # v40
-zktrie = { git = "https://github.com/scroll-tech/zktrie.git", branch = "main", features= ["rs_zktrie"] }
+zktrie = { git = "https://github.com/scroll-tech/zktrie.git", branch = "next", features= ["rs_zktrie"] }
 rkyv = { version = "0.7", features = ["validation"] }
 
 # for local development
@@ -42,6 +42,9 @@ pprof = { version = "0.13", features = ["flamegraph"], optional = true }
 #mpt-zktrie = { path = "../zkevm-circuits/zktrie" }
 #[patch."https://github.com/scroll-tech/revm"]
 #revm = { path = "../revm/crates/revm" }
+
+[patch."https://github.com/scroll-tech/zktrie.git"]
+zktrie = { git = "https://github.com/scroll-tech//zktrie.git", branch = "next" }
 
 [[bin]]
 name = "stateless-block-verifier"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ eth-types = { git = "https://github.com/scroll-tech/zkevm-circuits", features = 
 mpt-zktrie = { git = "https://github.com/scroll-tech/zkevm-circuits", branch = "feat/rkyv" }
 revm = { git = "https://github.com/scroll-tech/revm", branch = "scroll-evm-executor/v40" , default-features = false, features = ["scroll-default-handler", "std", "optional_no_base_fee"] } # v40
 zktrie = { git = "https://github.com/scroll-tech/zktrie.git", branch = "main", features= ["rs_zktrie"] }
-rkyv = "0.7"
+rkyv = { version = "0.7", features = ["validation"] }
 
 # for local development
 #eth-types = { path = "../zkevm-circuits/eth-types", features = ["scroll"] }
@@ -76,6 +76,14 @@ ethers-signers  = { git = "https://github.com/scroll-tech/ethers-rs.git", branch
 halo2curves = { git = "https://github.com/scroll-tech/halo2curves", branch = "v0.1.0" }
 primitive-types = { git = "https://github.com/scroll-tech/parity-common.git", branch = "feat/rkyv" }
 ethereum-types = { git = "https://github.com/scroll-tech/parity-common.git", branch = "feat/rkyv" }
+
+#ethers-core = { path = "../ethers-rs/ethers-core" }
+#ethers-providers = { path = "../ethers-rs/ethers-providers" }
+#ethers = { path = "../ethers-rs/ethers" }
+#ethers-etherscan = { path = "../ethers-rs/ethers-etherscan" }
+#ethers-signers  = { path = "../ethers-rs/ethers-signers" }
+#primitive-types = { path = "../parity-common/primitive-types" }
+#ethereum-types = { path = "../parity-common/ethereum-types" }
 
 [patch."https://github.com/privacy-scaling-explorations/bls12_381"]
 bls12_381 = { git = "https://github.com/scroll-tech/bls12_381", branch = "feat/impl_scalar_field" }

--- a/src/bin/trace-verifier/utils.rs
+++ b/src/bin/trace-verifier/utils.rs
@@ -19,7 +19,8 @@ pub fn verify(
 
     let v2_trace = BlockTraceV2::from(l2_trace.clone());
     let serialized = rkyv::to_bytes::<BlockTraceV2, 4096>(&v2_trace).unwrap();
-    let archived = unsafe { rkyv::archived_root::<BlockTraceV2>(&serialized[..]) };
+    // let archived = unsafe { rkyv::archived_root::<BlockTraceV2>(&serialized[..]) };
+    let archived = rkyv::check_archived_root::<BlockTraceV2>(&serialized[..]).unwrap();
 
     let now = Instant::now();
 

--- a/src/database.rs
+++ b/src/database.rs
@@ -19,25 +19,33 @@ pub struct ReadOnlyDB {
 impl ReadOnlyDB {
     /// Initialize an EVM database from a block trace.
     pub fn new<T: BlockRevmDbExt>(l2_trace: &T) -> Self {
+        println!("cycle-tracker-start: build ReadOnlyDB");
         let mut sdb = StateDB::new();
+        println!("cycle-tracker-start: insert StateDB account");
         for (addr, account) in l2_trace.accounts() {
             trace!("insert account {:?} {:?}", addr, account);
             sdb.set_account(&addr, account);
         }
+        println!("cycle-tracker-end: insert StateDB account");
 
+        println!("cycle-tracker-start: insert StateDB storage");
         for ((addr, key), val) in l2_trace.storages() {
             trace!("insert storage {:?} {:?} {:?}", addr, key, val);
             let key = key.to_word();
             *sdb.get_storage_mut(&addr, &key).1 = val;
         }
+        println!("cycle-tracker-end: insert StateDB storage");
 
         let mut code_db = CodeDB::new();
+        println!("cycle-tracker-start: insert CodeDB");
         for (hash, code) in l2_trace.codes() {
             // FIXME: use this later
             // let hash = code_db.insert(code_trace.code.to_vec());
             // assert_eq!(hash, code_trace.hash);
             code_db.insert_with_hash(hash, code);
         }
+        println!("cycle-tracker-end: insert CodeDB");
+        println!("cycle-tracker-end: build ReadOnlyDB");
 
         ReadOnlyDB { code_db, sdb }
     }

--- a/src/database.rs
+++ b/src/database.rs
@@ -1,10 +1,8 @@
-use crate::utils::{collect_account_proofs, collect_storage_proofs};
+use crate::utils::ext::BlockRevmDbExt;
 use eth_types::{
-    l2_types::BlockTraceV2,
-    state_db::{self, CodeDB, StateDB},
+    state_db::{CodeDB, StateDB},
     ToWord, H160,
 };
-use mpt_zktrie::state::ZktrieState;
 use revm::{
     db::DatabaseRef,
     primitives::{AccountInfo, Address, Bytecode, B256, U256},
@@ -20,30 +18,25 @@ pub struct ReadOnlyDB {
 
 impl ReadOnlyDB {
     /// Initialize an EVM database from a block trace.
-    pub fn new(l2_trace: &BlockTraceV2) -> Self {
+    pub fn new<T: BlockRevmDbExt>(l2_trace: &T) -> Self {
         let mut sdb = StateDB::new();
-        for parsed in
-            ZktrieState::parse_account_from_proofs(collect_account_proofs(&l2_trace.storage_trace))
-        {
-            let (addr, acc) = parsed.unwrap();
-            trace!("insert account {:?} {:?}", addr, acc);
-            sdb.set_account(&addr, state_db::Account::from(&acc));
+        for (addr, account) in l2_trace.accounts() {
+            trace!("insert account {:?} {:?}", addr, account);
+            sdb.set_account(&addr, account);
         }
 
-        for parsed in
-            ZktrieState::parse_storage_from_proofs(collect_storage_proofs(&l2_trace.storage_trace))
-        {
-            let ((addr, key), val) = parsed.unwrap();
+        for ((addr, key), val) in l2_trace.storages() {
+            trace!("insert storage {:?} {:?} {:?}", addr, key, val);
             let key = key.to_word();
-            *sdb.get_storage_mut(&addr, &key).1 = val.into();
+            *sdb.get_storage_mut(&addr, &key).1 = val;
         }
 
         let mut code_db = CodeDB::new();
-        for code_trace in l2_trace.codes.iter() {
+        for (hash, code) in l2_trace.codes() {
             // FIXME: use this later
             // let hash = code_db.insert(code_trace.code.to_vec());
             // assert_eq!(hash, code_trace.hash);
-            code_db.insert_with_hash(code_trace.hash, code_trace.code.to_vec());
+            code_db.insert_with_hash(hash, code);
         }
 
         ReadOnlyDB { code_db, sdb }

--- a/src/executor/builder.rs
+++ b/src/executor/builder.rs
@@ -1,6 +1,6 @@
 use crate::executor::hooks::ExecuteHooks;
 use crate::utils::ext::{BlockRevmDbExt, BlockTraceRevmExt, BlockZktrieExt};
-use crate::{EvmExecutor, HardforkConfig, ReadOnlyDB};
+use crate::{cycle_tracker_end, cycle_tracker_start, EvmExecutor, HardforkConfig, ReadOnlyDB};
 use revm::db::CacheDB;
 
 /// Builder for EVM executor.
@@ -55,7 +55,9 @@ impl EvmExecutorBuilder<HardforkConfig> {
         let mut db = CacheDB::new(ReadOnlyDB::new(l2_trace));
         self.hardfork_config.migrate(block_number, &mut db).unwrap();
 
+        cycle_tracker_start!("build ZktrieState");
         let zktrie = l2_trace.zktrie();
+        cycle_tracker_end!("build ZktrieState");
 
         EvmExecutor {
             db,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@ extern crate log;
 mod database;
 mod executor;
 mod hardfork;
+mod marcos;
 /// Utilities
 pub mod utils;
 

--- a/src/marcos.rs
+++ b/src/marcos.rs
@@ -1,0 +1,17 @@
+/// This macro is used to notify sp1 cycle tracker that a new routine is started.
+#[macro_export]
+macro_rules! cycle_tracker_start {
+    ($($arg:tt)*) => {
+        #[cfg(all(feature = "sp1", feature = "cycle-tracker"))]
+        println!("cycle-tracker-start: {}", format!($($arg)*));
+    };
+}
+
+/// This macro is used to notify sp1 cycle tracker that a routine is ended.
+#[macro_export]
+macro_rules! cycle_tracker_end {
+    ($($arg:tt)*) => {
+        #[cfg(all(feature = "sp1", feature = "cycle-tracker"))]
+        println!("cycle-tracker-end: {}", format!($($arg)*));
+    };
+}

--- a/src/utils/ext.rs
+++ b/src/utils/ext.rs
@@ -251,7 +251,6 @@ impl BlockRevmDbExt for BlockTrace {
             self.storage_trace
                 .proofs
                 .iter()
-                .flat_map(|m| m.iter())
                 .map(|(addr, b)| (addr, b.iter().map(|b| b.as_ref()))),
         )
         .map(|parsed| {
@@ -287,7 +286,6 @@ impl BlockRevmDbExt for BlockTraceV2 {
             self.storage_trace
                 .proofs
                 .iter()
-                .flat_map(|m| m.iter())
                 .map(|(addr, b)| (addr, b.iter().map(|b| b.as_ref()))),
         )
         .map(|parsed| {
@@ -319,16 +317,10 @@ impl BlockRevmDbExt for BlockTraceV2 {
 impl BlockRevmDbExt for ArchivedBlockTraceV2 {
     #[inline]
     fn accounts(&self) -> impl Iterator<Item = (Address, state_db::Account)> {
-        ZktrieState::parse_account_from_proofs(
-            self.storage_trace
-                .proofs
-                .iter()
-                .flat_map(|m| m.iter())
-                .map(|(addr, b)| {
-                    let addr: &Address = unsafe { mem::transmute(&addr.0) };
-                    (addr, b.iter().map(|b| b.as_ref()))
-                }),
-        )
+        ZktrieState::parse_account_from_proofs(self.storage_trace.proofs.iter().map(|(addr, b)| {
+            let addr: &Address = unsafe { mem::transmute(&addr.0) };
+            (addr, b.iter().map(|b| b.as_ref()))
+        }))
         .map(|parsed| {
             let (addr, acc) = parsed.unwrap();
             (addr, state_db::Account::from(&acc))
@@ -367,7 +359,6 @@ impl BlockZktrieExt for BlockTraceV2 {
             self.storage_trace
                 .proofs
                 .iter()
-                .flat_map(|m| m.iter())
                 .map(|(addr, b)| (addr, b.iter().map(|b| b.as_ref()))),
             self.storage_trace
                 .storage_proofs
@@ -395,14 +386,10 @@ impl BlockZktrieExt for ArchivedBlockTraceV2 {
         let old_root: H256 = self.storage_trace.root_before.0.into();
         let zktrie_state = ZktrieState::from_trace_with_additional(
             old_root,
-            self.storage_trace
-                .proofs
-                .iter()
-                .flat_map(|m| m.iter())
-                .map(|(addr, b)| {
-                    let addr = unsafe { mem::transmute(&addr.0) };
-                    (addr, b.iter().map(|b| b.as_ref()))
-                }),
+            self.storage_trace.proofs.iter().map(|(addr, b)| {
+                let addr = unsafe { mem::transmute(&addr.0) };
+                (addr, b.iter().map(|b| b.as_ref()))
+            }),
             self.storage_trace
                 .storage_proofs
                 .iter()

--- a/src/utils/ext.rs
+++ b/src/utils/ext.rs
@@ -1,0 +1,585 @@
+use eth_types::l2_types::{
+    ArchivedBlockTraceV2, ArchivedTransactionTrace, BlockTrace, BlockTraceV2, TransactionTrace,
+};
+use eth_types::{state_db, Address, Transaction, Word, H256};
+use mpt_zktrie::ZktrieState;
+use revm::primitives::{AccessListItem, TransactTo, TxEnv, B256, U256};
+use rkyv::Deserialize;
+use std::fmt::Debug;
+use std::mem;
+use zktrie::ZkTrie;
+
+/// Revm extension trait for BlockTrace
+pub trait BlockTraceRevmExt {
+    type Tx: TxRevmExt + Debug;
+
+    /// block number
+    fn number(&self) -> u64;
+    /// block hash
+    fn block_hash(&self) -> B256;
+    /// chain id
+    fn chain_id(&self) -> u64;
+    /// coinbase address
+    fn coinbase(&self) -> revm::primitives::Address;
+    /// timestamp
+    fn timestamp(&self) -> U256;
+    /// gas limit
+    fn gas_limit(&self) -> U256;
+    /// base fee per gas
+    fn base_fee_per_gas(&self) -> Option<U256>;
+    /// difficulty
+    fn difficulty(&self) -> U256;
+    /// prevrandao
+    fn prevrandao(&self) -> Option<B256>;
+
+    /// transactions
+    fn transactions(&self) -> impl Iterator<Item = &Self::Tx>;
+
+    /// creates `revm::primitives::BlockEnv`
+    fn env(&self) -> revm::primitives::BlockEnv {
+        revm::primitives::BlockEnv {
+            number: U256::from_limbs([self.number(), 0, 0, 0]),
+            coinbase: self.coinbase(),
+            timestamp: self.timestamp(),
+            gas_limit: self.gas_limit(),
+            basefee: self.base_fee_per_gas().unwrap_or_default(),
+            difficulty: self.difficulty(),
+            prevrandao: self.prevrandao(),
+            blob_excess_gas_and_price: None,
+        }
+    }
+}
+
+/// Revm extension trait for init db
+pub trait BlockRevmDbExt {
+    fn accounts(&self) -> impl Iterator<Item = (Address, state_db::Account)>;
+    fn storages(&self) -> impl Iterator<Item = ((Address, H256), Word)>;
+    fn codes(&self) -> impl Iterator<Item = (H256, Vec<u8>)>;
+}
+
+pub trait BlockZktrieExt {
+    fn zktrie(&self) -> ZkTrie;
+}
+
+pub trait TxRevmExt {
+    /// get the raw tx type
+    fn raw_type(&self) -> u8;
+    fn caller(&self) -> revm::primitives::Address;
+    fn gas_limit(&self) -> u64;
+    fn gas_price(&self) -> U256;
+    fn transact_to(&self) -> TransactTo;
+    fn value(&self) -> U256;
+    fn data(&self) -> revm::primitives::Bytes;
+    fn nonce(&self) -> u64;
+    fn chain_id(&self) -> u64;
+    fn access_list(&self) -> Vec<AccessListItem>;
+    fn gas_priority_fee(&self) -> Option<U256>;
+
+    /// creates `revm::primitives::TxEnv`
+    fn tx_env(&self) -> TxEnv {
+        TxEnv {
+            caller: self.caller(),
+            gas_limit: self.gas_limit(),
+            gas_price: self.gas_price(),
+            transact_to: self.transact_to(),
+            value: self.value(),
+            data: self.data(),
+            nonce: Some(self.nonce()),
+            chain_id: Some(self.chain_id()),
+            access_list: self.access_list(),
+            gas_priority_fee: self.gas_priority_fee(),
+            ..Default::default()
+        }
+    }
+
+    fn to_eth_tx(
+        &self,
+        block_hash: B256,
+        block_number: u64,
+        transaction_index: usize,
+        base_fee_per_gas: Option<U256>,
+    ) -> Transaction;
+}
+
+impl BlockTraceRevmExt for BlockTrace {
+    type Tx = TransactionTrace;
+
+    #[inline]
+    fn number(&self) -> u64 {
+        self.header.number.expect("incomplete block").as_u64()
+    }
+    #[inline]
+    fn block_hash(&self) -> B256 {
+        self.header.hash.expect("incomplete block").0.into()
+    }
+    #[inline]
+    fn chain_id(&self) -> u64 {
+        self.chain_id
+    }
+    #[inline]
+    fn coinbase(&self) -> revm::primitives::Address {
+        self.coinbase.address.0.into()
+    }
+    #[inline]
+    fn timestamp(&self) -> U256 {
+        U256::from_limbs(self.header.timestamp.0)
+    }
+    #[inline]
+    fn gas_limit(&self) -> U256 {
+        U256::from_limbs(self.header.gas_limit.0)
+    }
+    #[inline]
+    fn base_fee_per_gas(&self) -> Option<U256> {
+        self.header.base_fee_per_gas.map(|b| U256::from_limbs(b.0))
+    }
+    #[inline]
+    fn difficulty(&self) -> U256 {
+        U256::from_limbs(self.header.difficulty.0)
+    }
+    #[inline]
+    fn prevrandao(&self) -> Option<B256> {
+        self.header
+            .mix_hash
+            .map(|h| revm::primitives::B256::from(h.0))
+    }
+    #[inline]
+    fn transactions(&self) -> impl Iterator<Item = &Self::Tx> {
+        self.transactions.iter()
+    }
+}
+
+impl BlockTraceRevmExt for BlockTraceV2 {
+    type Tx = TransactionTrace;
+    #[inline]
+    fn number(&self) -> u64 {
+        self.header.number.as_u64()
+    }
+    #[inline]
+    fn block_hash(&self) -> B256 {
+        self.header.hash.0.into()
+    }
+    #[inline]
+    fn chain_id(&self) -> u64 {
+        self.chain_id
+    }
+    #[inline]
+    fn coinbase(&self) -> revm::primitives::Address {
+        self.coinbase.address.0.into()
+    }
+    #[inline]
+    fn timestamp(&self) -> U256 {
+        U256::from_limbs(self.header.timestamp.0)
+    }
+    #[inline]
+    fn gas_limit(&self) -> U256 {
+        U256::from_limbs(self.header.gas_limit.0)
+    }
+    #[inline]
+    fn base_fee_per_gas(&self) -> Option<U256> {
+        self.header.base_fee_per_gas.map(|b| U256::from_limbs(b.0))
+    }
+    #[inline]
+    fn difficulty(&self) -> U256 {
+        U256::from_limbs(self.header.difficulty.0)
+    }
+    #[inline]
+    fn prevrandao(&self) -> Option<B256> {
+        self.header
+            .mix_hash
+            .map(|h| revm::primitives::B256::from(h.0))
+    }
+    #[inline]
+    fn transactions(&self) -> impl Iterator<Item = &Self::Tx> {
+        self.transactions.iter()
+    }
+}
+
+impl BlockTraceRevmExt for ArchivedBlockTraceV2 {
+    type Tx = ArchivedTransactionTrace;
+    #[inline]
+    fn number(&self) -> u64 {
+        self.header.number.0[0]
+    }
+    #[inline]
+    fn block_hash(&self) -> B256 {
+        self.header.hash.0.into()
+    }
+    #[inline]
+    fn chain_id(&self) -> u64 {
+        self.chain_id
+    }
+    #[inline]
+    fn coinbase(&self) -> revm::primitives::Address {
+        self.coinbase.address.0.into()
+    }
+    #[inline]
+    fn timestamp(&self) -> U256 {
+        U256::from_limbs(self.header.timestamp.0)
+    }
+    #[inline]
+    fn gas_limit(&self) -> U256 {
+        U256::from_limbs(self.header.gas_limit.0)
+    }
+    #[inline]
+    fn base_fee_per_gas(&self) -> Option<U256> {
+        self.header
+            .base_fee_per_gas
+            .as_ref()
+            .map(|b| U256::from_limbs(b.0))
+    }
+    #[inline]
+    fn difficulty(&self) -> U256 {
+        U256::from_limbs(self.header.difficulty.0)
+    }
+    #[inline]
+    fn prevrandao(&self) -> Option<B256> {
+        self.header
+            .mix_hash
+            .as_ref()
+            .map(|h| revm::primitives::B256::from(h.0))
+    }
+    #[inline]
+    fn transactions(&self) -> impl Iterator<Item = &Self::Tx> {
+        self.transactions.iter()
+    }
+}
+
+impl BlockRevmDbExt for BlockTrace {
+    #[inline]
+    fn accounts(&self) -> impl Iterator<Item = (Address, state_db::Account)> {
+        ZktrieState::parse_account_from_proofs(
+            self.storage_trace
+                .proofs
+                .iter()
+                .flat_map(|m| m.iter())
+                .map(|(addr, b)| (addr, b.iter().map(|b| b.as_ref()))),
+        )
+        .map(|parsed| {
+            let (addr, acc) = parsed.unwrap();
+            (addr, state_db::Account::from(&acc))
+        })
+    }
+    #[inline]
+    fn storages(&self) -> impl Iterator<Item = ((Address, H256), Word)> {
+        ZktrieState::parse_storage_from_proofs(self.storage_trace.storage_proofs.iter().flat_map(
+            |(addr, map)| {
+                map.iter()
+                    .map(move |(sk, bts)| (addr, sk, bts.iter().map(|b| b.as_ref())))
+            },
+        ))
+        .map(|parsed| {
+            let ((addr, key), val) = parsed.unwrap();
+            ((addr, key), val.into())
+        })
+    }
+    #[inline]
+    fn codes(&self) -> impl Iterator<Item = (H256, Vec<u8>)> {
+        self.codes
+            .iter()
+            .map(|trace| (trace.hash, trace.code.to_vec()))
+    }
+}
+
+impl BlockRevmDbExt for BlockTraceV2 {
+    #[inline]
+    fn accounts(&self) -> impl Iterator<Item = (Address, state_db::Account)> {
+        ZktrieState::parse_account_from_proofs(
+            self.storage_trace
+                .proofs
+                .iter()
+                .flat_map(|m| m.iter())
+                .map(|(addr, b)| (addr, b.iter().map(|b| b.as_ref()))),
+        )
+        .map(|parsed| {
+            let (addr, acc) = parsed.unwrap();
+            (addr, state_db::Account::from(&acc))
+        })
+    }
+    #[inline]
+    fn storages(&self) -> impl Iterator<Item = ((Address, H256), Word)> {
+        ZktrieState::parse_storage_from_proofs(self.storage_trace.storage_proofs.iter().flat_map(
+            |(addr, map)| {
+                map.iter()
+                    .map(move |(sk, bts)| (addr, sk, bts.iter().map(|b| b.as_ref())))
+            },
+        ))
+        .map(|parsed| {
+            let ((addr, key), val) = parsed.unwrap();
+            ((addr, key), val.into())
+        })
+    }
+    #[inline]
+    fn codes(&self) -> impl Iterator<Item = (H256, Vec<u8>)> {
+        self.codes
+            .iter()
+            .map(|trace| (trace.hash, trace.code.to_vec()))
+    }
+}
+
+impl BlockRevmDbExt for ArchivedBlockTraceV2 {
+    #[inline]
+    fn accounts(&self) -> impl Iterator<Item = (Address, state_db::Account)> {
+        ZktrieState::parse_account_from_proofs(
+            self.storage_trace
+                .proofs
+                .iter()
+                .flat_map(|m| m.iter())
+                .map(|(addr, b)| {
+                    let addr: &Address = unsafe { mem::transmute(&addr.0) };
+                    (addr, b.iter().map(|b| b.as_ref()))
+                }),
+        )
+        .map(|parsed| {
+            let (addr, acc) = parsed.unwrap();
+            (addr, state_db::Account::from(&acc))
+        })
+    }
+    #[inline]
+    fn storages(&self) -> impl Iterator<Item = ((Address, H256), Word)> {
+        ZktrieState::parse_storage_from_proofs(self.storage_trace.storage_proofs.iter().flat_map(
+            |(addr, map)| {
+                let addr: &Address = unsafe { mem::transmute(&addr.0) };
+
+                map.iter().map(move |(sk, bts)| {
+                    let sk: &H256 = unsafe { mem::transmute(&sk.0) };
+                    (addr, sk, bts.iter().map(|b| b.as_ref()))
+                })
+            },
+        ))
+        .map(|parsed| {
+            let ((addr, key), val) = parsed.unwrap();
+            ((addr, key), val.into())
+        })
+    }
+    #[inline]
+    fn codes(&self) -> impl Iterator<Item = (H256, Vec<u8>)> {
+        self.codes
+            .iter()
+            .map(|trace| (trace.hash.0.into(), trace.code.to_vec()))
+    }
+}
+
+impl BlockZktrieExt for BlockTraceV2 {
+    fn zktrie(&self) -> ZkTrie {
+        let old_root = self.storage_trace.root_before;
+        let zktrie_state = ZktrieState::from_trace_with_additional(
+            old_root,
+            self.storage_trace
+                .proofs
+                .iter()
+                .flat_map(|m| m.iter())
+                .map(|(addr, b)| (addr, b.iter().map(|b| b.as_ref()))),
+            self.storage_trace
+                .storage_proofs
+                .iter()
+                .flat_map(|(addr, map)| {
+                    map.iter()
+                        .map(move |(sk, bts)| (addr, sk, bts.iter().map(|b| b.as_ref())))
+                }),
+            self.storage_trace
+                .deletion_proofs
+                .iter()
+                .map(|s| s.as_ref()),
+        )
+        .unwrap();
+        let root = *zktrie_state.root();
+        debug!("building partial statedb done, root {}", hex::encode(root));
+
+        let mem_db = zktrie_state.into_inner();
+        mem_db.new_trie(&root).unwrap()
+    }
+}
+
+impl BlockZktrieExt for ArchivedBlockTraceV2 {
+    fn zktrie(&self) -> ZkTrie {
+        let old_root: H256 = self.storage_trace.root_before.0.into();
+        let zktrie_state = ZktrieState::from_trace_with_additional(
+            old_root,
+            self.storage_trace
+                .proofs
+                .iter()
+                .flat_map(|m| m.iter())
+                .map(|(addr, b)| {
+                    let addr = unsafe { mem::transmute(&addr.0) };
+                    (addr, b.iter().map(|b| b.as_ref()))
+                }),
+            self.storage_trace
+                .storage_proofs
+                .iter()
+                .flat_map(|(addr, map)| {
+                    let addr = unsafe { mem::transmute(&addr.0) };
+                    map.iter().map(move |(sk, bts)| {
+                        let sk = unsafe { mem::transmute(&sk.0) };
+                        (addr, sk, bts.iter().map(|b| b.as_ref()))
+                    })
+                }),
+            self.storage_trace
+                .deletion_proofs
+                .iter()
+                .map(|s| s.as_ref()),
+        )
+        .unwrap();
+        let root = *zktrie_state.root();
+        debug!("building partial statedb done, root {}", hex::encode(root));
+
+        let mem_db = zktrie_state.into_inner();
+        mem_db.new_trie(&root).unwrap()
+    }
+}
+
+impl TxRevmExt for TransactionTrace {
+    #[inline]
+    fn raw_type(&self) -> u8 {
+        self.type_
+    }
+    #[inline]
+    fn caller(&self) -> revm::precompile::Address {
+        self.from.0.into()
+    }
+    #[inline]
+    fn gas_limit(&self) -> u64 {
+        self.gas
+    }
+    #[inline]
+    fn gas_price(&self) -> U256 {
+        U256::from_limbs(self.gas_price.0)
+    }
+    #[inline]
+    fn transact_to(&self) -> TransactTo {
+        match self.to {
+            Some(to) => TransactTo::Call(to.0.into()),
+            None => TransactTo::Create,
+        }
+    }
+    #[inline]
+    fn value(&self) -> U256 {
+        U256::from_limbs(self.value.0)
+    }
+    #[inline]
+    fn data(&self) -> revm::precompile::Bytes {
+        revm::precompile::Bytes::copy_from_slice(self.data.as_ref())
+    }
+    #[inline]
+    fn nonce(&self) -> u64 {
+        self.nonce
+    }
+    #[inline]
+    fn chain_id(&self) -> u64 {
+        self.chain_id.as_u64()
+    }
+    #[inline]
+    fn access_list(&self) -> Vec<AccessListItem> {
+        self.access_list
+            .as_ref()
+            .map(|v| {
+                v.iter()
+                    .map(|e| AccessListItem {
+                        address: e.address.0.into(),
+                        storage_keys: e
+                            .storage_keys
+                            .iter()
+                            .map(|s| s.to_fixed_bytes().into())
+                            .collect(),
+                    })
+                    .collect()
+            })
+            .unwrap_or_default()
+    }
+    #[inline]
+    fn gas_priority_fee(&self) -> Option<U256> {
+        self.gas_tip_cap.map(|g| U256::from_limbs(g.0))
+    }
+    #[inline]
+    fn to_eth_tx(
+        &self,
+        block_hash: B256,
+        block_number: u64,
+        transaction_index: usize,
+        base_fee_per_gas: Option<U256>,
+    ) -> Transaction {
+        self.to_eth_tx(
+            Some(H256::from(block_hash.0)),
+            Some(block_number.into()),
+            Some((transaction_index as u64).into()),
+            base_fee_per_gas.map(|b| eth_types::U256(*b.as_limbs())),
+        )
+    }
+}
+
+impl TxRevmExt for ArchivedTransactionTrace {
+    #[inline]
+    fn raw_type(&self) -> u8 {
+        self.type_
+    }
+    #[inline]
+    fn caller(&self) -> revm::precompile::Address {
+        self.from.0.into()
+    }
+    #[inline]
+    fn gas_limit(&self) -> u64 {
+        self.gas
+    }
+    #[inline]
+    fn gas_price(&self) -> U256 {
+        U256::from_limbs(self.gas_price.0)
+    }
+    #[inline]
+    fn transact_to(&self) -> TransactTo {
+        match self.to.as_ref() {
+            Some(to) => TransactTo::Call(to.0.into()),
+            None => TransactTo::Create,
+        }
+    }
+    #[inline]
+    fn value(&self) -> U256 {
+        U256::from_limbs(self.value.0)
+    }
+    #[inline]
+    fn data(&self) -> revm::precompile::Bytes {
+        revm::precompile::Bytes::copy_from_slice(self.data.as_ref())
+    }
+    #[inline]
+    fn nonce(&self) -> u64 {
+        self.nonce
+    }
+    #[inline]
+    fn chain_id(&self) -> u64 {
+        self.chain_id.0[0]
+    }
+    #[inline]
+    fn access_list(&self) -> Vec<AccessListItem> {
+        self.access_list
+            .as_ref()
+            .map(|v| {
+                v.iter()
+                    .map(|e| AccessListItem {
+                        address: e.address.0.into(),
+                        storage_keys: e.storage_keys.iter().map(|s| s.0.into()).collect(),
+                    })
+                    .collect()
+            })
+            .unwrap_or_default()
+    }
+    #[inline]
+    fn gas_priority_fee(&self) -> Option<U256> {
+        self.gas_tip_cap.as_ref().map(|g| U256::from_limbs(g.0))
+    }
+    #[inline]
+    fn to_eth_tx(
+        &self,
+        block_hash: B256,
+        block_number: u64,
+        transaction_index: usize,
+        base_fee_per_gas: Option<U256>,
+    ) -> Transaction {
+        // FIXME: zero copy here pls
+        let tx_trace: TransactionTrace =
+            Deserialize::<TransactionTrace, _>::deserialize(self, &mut rkyv::Infallible).unwrap();
+        tx_trace.to_eth_tx(
+            Some(H256::from(block_hash.0)),
+            Some(block_number.into()),
+            Some((transaction_index as u64).into()),
+            base_fee_per_gas.map(|b| eth_types::U256(*b.as_limbs())),
+        )
+    }
+}

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,30 +1,9 @@
-use eth_types::{
-    l2_types::{ExecutionResult, StorageTrace},
-    Address, H256,
-};
+use eth_types::l2_types::ExecutionResult;
 use log::Level;
 use revm::DatabaseRef;
 use std::fmt::Debug;
 
-pub(crate) fn collect_account_proofs(
-    storage_trace: &StorageTrace,
-) -> impl Iterator<Item = (&Address, impl IntoIterator<Item = &[u8]>)> + Clone {
-    storage_trace.proofs.iter().flat_map(|kv_map| {
-        kv_map
-            .iter()
-            .map(|(k, bts)| (k, bts.iter().map(|b| b.as_ref())))
-    })
-}
-
-pub(crate) fn collect_storage_proofs(
-    storage_trace: &StorageTrace,
-) -> impl Iterator<Item = (&Address, &H256, impl IntoIterator<Item = &[u8]>)> + Clone {
-    storage_trace.storage_proofs.iter().flat_map(|(k, kv_map)| {
-        kv_map
-            .iter()
-            .map(move |(sk, bts)| (k, sk, bts.iter().map(|b| b.as_ref())))
-    })
-}
+pub(crate) mod ext;
 
 /// Check the post state of the block with the execution result.
 pub fn post_check<DB: DatabaseRef>(db: DB, exec: &ExecutionResult) -> bool


### PR DESCRIPTION
# Background

We want to minimize the cost of deserialization in zkvm.

## Why rkyv

rkyv is capable of "zero-copy" deserialization, which means, there won't a "parsing" part.

# Related Pull Requests

- https://github.com/scroll-tech/ethers-rs/pull/2
- https://github.com/scroll-tech/parity-common/pull/1
- https://github.com/scroll-tech/zkevm-circuits/pull/1378

# Future works

The "zero-copy" deserialized types are another type like `ArchiveFoo` for `Foo`.
The associated method of `Foo` won't be impl for `ArchiveFoo`.

We should find a better way to utilize this.

p.s. there are some unsafe codes using transmute, don't worry, it's sound.
