### PR TITLE
Typos fix

### DIFF
--- a/crates/stateful/README.md
+++ b/crates/stateful/README.md
@@ -1,6 +1,6 @@
 # Stateful Block Verifier
 
-With the `sled` feature enabled, the zkTrie can persisit storage on disk,
+With the `sled` feature enabled, the zkTrie can persist storage on disk,
 so we can run the verifier in stateful mode, which means we do not need the
 zktrie proofs to execute the transaction since we have all storage available.
 


### PR DESCRIPTION
### Changes

1. **File:** `/crates/stateful/README.md`
    - Fixed `persisit` to `persist` (Line 3)

### Purpose

- Improved documentation accuracy by fixing typographical errors.
- Ensured better readability and consistency.