### PR TITLE
Typos fix

### DIFF
--- a/crates/stateful/README.md
+++ b/crates/stateful/README.md
@@ -9,7 +9,7 @@ than `scroll_getBlockTraceByNumberOrHash`.
 
 ## How to run
 
-*Note: In debug mode, it runs both stateless and stateful to performe sanity
+*Note: In debug mode, it runs both stateless and stateful to perform, performed sanity
 check, which requires the rpc endpoint supports `scroll_getBlockTraceByNumberOrHash`
 
 ```bash


### PR DESCRIPTION
Fix: Corrected typos in source files

**Changes**

Corrected typo in /crates/stateful/README.md (Line 12)

"performe" → "perform, performed"

**Purpose**

Improved code accuracy and professionalism by fixing typos.