### PR TITLE
[breaking change] feat: use standard ExecutionWitness

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -428,6 +428,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloy-rpc-types-debug"
+version = "1.0.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9b6f0482c82310366ec3dcf4e5212242f256a69fcf1a26e5017e6704091ee95"
+dependencies = [
+ "alloy-primitives",
+ "derive_more",
+ "serde",
+]
+
+[[package]]
 name = "alloy-rpc-types-engine"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5440,6 +5451,7 @@ dependencies = [
  "alloy-evm",
  "alloy-network",
  "alloy-primitives",
+ "alloy-rpc-types-debug",
  "alloy-rpc-types-eth",
  "alloy-serde",
  "auto_impl",
@@ -5494,6 +5506,7 @@ dependencies = [
  "async-trait",
  "futures",
  "sbv-primitives",
+ "serde",
  "thiserror",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ alloy-eips = { version = "1.0", default-features = false }
 alloy-network = { version = "1.0", default-features = false }
 alloy-provider = { version = "1.0", default-features = false }
 alloy-rpc-types-eth = { version = "1.0", default-features = false }
+alloy-rpc-types-debug = { version = "1.0", default-features = false }
 alloy-serde = { version = "1.0", default-features = false }
 alloy-transport = { version = "1.0", default-features = false }
 # https://github.com/alloy-rs/rlp

--- a/crates/primitives/Cargo.toml
+++ b/crates/primitives/Cargo.toml
@@ -26,6 +26,7 @@ alloy-eips = { workspace = true, optional = true }
 alloy-evm = { workspace = true, optional = true }
 alloy-network = { workspace = true, optional = true }
 alloy-rpc-types-eth = { workspace = true, optional = true }
+alloy-rpc-types-debug = { workspace = true, optional = true }
 alloy-serde = { workspace = true, optional = true }
 
 alloy-primitives.workspace = true
@@ -80,7 +81,7 @@ reth-primitives-types = [
 reth-evm-types = ["reth-types", "dep:reth-evm", "dep:reth-evm-ethereum"]
 reth-execution-types = ["reth-types", "dep:reth-execution-types"]
 revm-types = ["dep:revm"]
-rpc-types = ["dep:alloy-rpc-types-eth", "eips"]
+rpc-types = ["dep:alloy-rpc-types-eth", "dep:alloy-rpc-types-debug", "eips"]
 ethereum-all = [
   "chainspec",
   "consensus-types",

--- a/crates/primitives/src/types/witness.rs
+++ b/crates/primitives/src/types/witness.rs
@@ -1,24 +1,9 @@
 use crate::{
     B256, BlockNumber, Bytes, ChainId, U256,
-    alloy_primitives::map::B256HashMap,
     types::{BlockHeader, Transaction, Withdrawal},
 };
 
-/// Represents the execution witness of a block. Contains an optional map of state preimages.
-#[derive(Debug, Clone, Eq, PartialEq)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-pub struct ExecutionWitness {
-    /// Map of all hashed trie nodes to their preimages that were required during the execution of
-    /// the block, including during state root recomputation.
-    ///
-    /// `keccak(rlp(node)) => rlp(node)`
-    pub state: B256HashMap<Bytes>,
-    /// Map of all contract codes (created / accessed) to their preimages that were required during
-    /// the execution of the block, including during state root recomputation.
-    ///
-    /// `keccak(bytecodes) => bytecodes`
-    pub codes: B256HashMap<Bytes>,
-}
+pub use alloy_rpc_types_debug::ExecutionWitness;
 
 /// Witness for a block.
 #[derive(Debug, Clone, Hash, Eq, PartialEq)]

--- a/crates/utils/Cargo.toml
+++ b/crates/utils/Cargo.toml
@@ -19,6 +19,7 @@ alloy-transport.workspace = true
 async-trait.workspace = true
 futures.workspace = true
 thiserror.workspace = true
+serde = { workspace = true, features = ["derive"] }
 
 sbv-primitives = { workspace = true, features = [
   "serde",

--- a/crates/utils/src/witness.rs
+++ b/crates/utils/src/witness.rs
@@ -97,8 +97,8 @@ impl WitnessBuilder {
             withdrawals: block
                 .withdrawals
                 .map(|w| w.iter().map(From::from).collect()),
-            states: execution_witness.state.into_values().collect(),
-            codes: execution_witness.codes.into_values().collect(),
+            states: execution_witness.state,
+            codes: execution_witness.codes,
         })
     }
 }


### PR DESCRIPTION
# Breaking Change

- The type `sbv_primitives::types::ExecutionWitness` now is an alias to `alloy_rpc_types_debug::ExecutionWitness`, which:
  - `state` is `Vec<Bytes>` instead of `B256HashMap<Bytes>`
  - `codes` is `Vec<Bytes>` instead of `B256HashMap<Bytes>`
- The `ProviderExt::debug_execution_witness` has return type of `TransportResult<ExecutionWitness>`, changed as mentioned above.

# Note

`sbv_primitives::types::ExecutionWitness` now has two extra fields `keys` and `headers`.
It's not recommend to use new field `headers` in your code, which will be always empty in the future.